### PR TITLE
delete warn log

### DIFF
--- a/zan-extension/src/factory/FactoryProcess.c
+++ b/zan-extension/src/factory/FactoryProcess.c
@@ -170,8 +170,6 @@ static int swFactoryProcess_dispatch(swFactory *factory, swDispatchData *task)
         {
             if (!(task->data.info.type == SW_EVENT_CLOSE && conn->close_force))
             {
-                swWarn("dispatch[type=%d] failed, connection#%d[session_id=%d] is closed by server.",
-                        task->data.info.type, task->data.info.fd, conn->session_id);
                 return SW_OK;
             }
         }


### PR DESCRIPTION
fix a lot of warning log

```
[2017-07-04 12:19:22 #17640.3]  WARNING swFactoryProcess_dispatch: dispatch[type=4] failed, connection#51[session_id=23141] is closed by server.
[2017-07-04 12:19:23 #17640.3]  WARNING swFactoryProcess_dispatch: dispatch[type=4] failed, connection#51[session_id=23142] is closed by server.
[2017-07-04 12:19:23 #17640.3]  WARNING swFactoryProcess_dispatch: dispatch[type=4] failed, connection#51[session_id=23147] is closed by server.
```