### PR TITLE
修复即使安装curl 也报libcurl not installed

### DIFF
--- a/zan-extension/config.m4
+++ b/zan-extension/config.m4
@@ -233,7 +233,7 @@ if test "$PHP_ZAN" != "no"; then
         fi
     fi
     if test "$PHP_CURL" != "no"; then
-        for i in /usr /usr/local /usr/local/Cellar/curl/7.47.1; do
+        for i in /usr /usr/local /usr/local/Cellar/curl/*; do
             if test -f $i/include/curl/curl.h; then
                 CURL_DIR=$i
             fi


### PR DESCRIPTION
场景：用家里的mac电脑安装zan扩展 ./configure后 报libcurl not installed
本机早已安装最新的curl版本：
[image](https://user-images.githubusercontent.com/5779513/28241716-381e79b6-69cc-11e7-9f58-bf61c4c828b6.png)
看了下原来是限制了版本号，改过之后通过编译
