### PR TITLE
use swSignalHander instead of __sighandler_t

### DIFF
--- a/zan-extension/include/swSignal.h
+++ b/zan-extension/include/swSignal.h
@@ -28,10 +28,10 @@ extern "C"
 {
 #endif
 
-typedef void (*swSignalFunc)(int);
+typedef void (*swSignalHander)(int);
 
-swSignalFunc swSignal_set(int sig, swSignalFunc func, int restart, int mask);
-void swSignal_add(int signo, swSignalFunc func);
+swSignalHander swSignal_set(int sig, swSignalHander func, int restart, int mask);
+void swSignal_add(int signo, swSignalHander func);
 void swSignal_callback(int signo);
 void swSignal_clear(void);
 void swSignal_none(void);

--- a/zan-extension/src/signal/Signal.c
+++ b/zan-extension/src/signal/Signal.c
@@ -25,7 +25,7 @@
 
 #ifdef HAVE_SIGNALFD
 #include <sys/signalfd.h>
-static void swSignalfd_set(int signo, __sighandler_t callback);
+static void swSignalfd_set(int signo, swSignalHander callback);
 static void swSignalfd_clear();
 static int swSignalfd_onSignal(swReactor *reactor, swEvent *event);
 
@@ -37,7 +37,7 @@ static int signal_fd = 0;
 
 typedef struct
 {
-    swSignalFunc callback;
+    swSignalHander callback;
     uint16_t signo;
     uint16_t active;
 } swSignal;
@@ -63,7 +63,7 @@ void swSignal_none(void)
 /**
  * setup signal
  */
-swSignalFunc swSignal_set(int sig, swSignalFunc func, int restart, int mask)
+swSignalHander swSignal_set(int sig, swSignalHander func, int restart, int mask)
 {
     //ignore
     if (func == NULL)
@@ -96,7 +96,7 @@ swSignalFunc swSignal_set(int sig, swSignalFunc func, int restart, int mask)
     return oact.sa_handler;
 }
 
-void swSignal_add(int signo, swSignalFunc func)
+void swSignal_add(int signo, swSignalHander func)
 {
 #ifdef HAVE_SIGNALFD
     if (ServerG.use_signalfd)
@@ -133,7 +133,7 @@ void swSignal_callback(int signo)
         return;
     }
 
-    swSignalFunc callback = signals[signo].callback;
+    swSignalHander callback = signals[signo].callback;
     if (!callback)
     {
         zanWarn("signal[%d] callback is null.", signo);
@@ -157,7 +157,7 @@ void swSignal_clear(void)
         {
             if (signals[index].active)
             {
-                swSignal_set(signals[index].signo, (swSignalFunc) -1, 1, 0);
+                swSignal_set(signals[index].signo, (swSignalHander) -1, 1, 0);
             }
         }
     }
@@ -172,7 +172,7 @@ void swSignalfd_init()
     bzero(&signals, sizeof(signals));
 }
 
-static void swSignalfd_set(int signo, __sighandler_t callback)
+static void swSignalfd_set(int signo, swSignalHander callback)
 {
     if (callback == NULL && signals[signo].active)
     {


### PR DESCRIPTION
failed at `php:7.0-cli-alpine`.

Dockerfile:
```
FROM php:7.0-cli-alpine

RUN apk --no-cache add curl-dev
RUN docker-php-ext-install sockets

RUN curl -fsSL https://github.com/youzan/zan/archive/master.tar.gz -o zan.tar.gz && \
    mkdir /tmp/zan -p && tar -xf zan.tar.gz -C /tmp/zan --strip-components=1 && rm zan.tar.gz && \
    /usr/local/bin/docker-php-ext-configure /tmp/zan/zan-extension/ --enable-openssl && \
    docker-php-ext-install /tmp/zan/zan-extension/ && \
    rm -rf /tmp/zan/
```

build log:
```
...
cc -I. -I/tmp/zan/zan-extension -DPHP_ATOM_INC -I/tmp/zan/zan-extension/include -I/tmp/zan/zan-extension/main -I/tmp/zan/zan-extension -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -I/tmp/zan/zan-extension/include -fstack-protector-strong -fpic -fpie -O2 -DHAVE_CONFIG_H -Wall -fstack-protector-strong -fpic -fpie -O2 -std=gnu99 -fbounds-check -pthread -fstack-check -fstack-protector -fstack-protector-all -fno-strict-aliasing -c /tmp/zan/zan-extension/src/dns/DNS.c  -fPIC -DPIC -o src/dns/.libs/DNS.o
/bin/sh /tmp/zan/zan-extension/libtool --mode=compile cc  -I. -I/tmp/zan/zan-extension -DPHP_ATOM_INC -I/tmp/zan/zan-extension/include -I/tmp/zan/zan-extension/main -I/tmp/zan/zan-extension -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -I/tmp/zan/zan-extension/include  -fstack-protector-strong -fpic -fpie -O2 -DHAVE_CONFIG_H  -Wall -fstack-protector-strong -fpic -fpie -O2 -std=gnu99 -fbounds-check -pthread -fstack-check -fstack-protector -fstack-protector-all -fno-strict-aliasing   -c /tmp/zan/zan-extension/src/signal/Signal.c -o src/signal/Signal.lo 
mkdir src/signal/.libs
 cc -I. -I/tmp/zan/zan-extension -DPHP_ATOM_INC -I/tmp/zan/zan-extension/include -I/tmp/zan/zan-extension/main -I/tmp/zan/zan-extension -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -I/tmp/zan/zan-extension/include -fstack-protector-strong -fpic -fpie -O2 -DHAVE_CONFIG_H -Wall -fstack-protector-strong -fpic -fpie -O2 -std=gnu99 -fbounds-check -pthread -fstack-check -fstack-protector -fstack-protector-all -fno-strict-aliasing -c /tmp/zan/zan-extension/src/signal/Signal.c  -fPIC -DPIC -o src/signal/.libs/Signal.o
/tmp/zan/zan-extension/src/signal/Signal.c:28:39: error: unknown type name '__sighandler_t'
 static void swSignalfd_set(int signo, __sighandler_t callback);
                                       ^
/tmp/zan/zan-extension/src/signal/Signal.c: In function 'swSignal_add':
/tmp/zan/zan-extension/src/signal/Signal.c:104:9: warning: implicit declaration of function 'swSignalfd_set' [-Wimplicit-function-declaration]
         swSignalfd_set(signo, func);
         ^
/tmp/zan/zan-extension/src/signal/Signal.c: At top level:
/tmp/zan/zan-extension/src/signal/Signal.c:175:39: error: unknown type name '__sighandler_t'
 static void swSignalfd_set(int signo, __sighandler_t callback)
                                       ^
Makefile:324: recipe for target 'src/signal/Signal.lo' failed
make: *** [src/signal/Signal.lo] Error 1
The command '/bin/sh -c curl -fsSL https://github.com/youzan/zan/archive/master.tar.gz -o zan.tar.gz &&     mkdir /tmp/zan -p && tar -xf zan.tar.gz -C /tmp/zan --strip-components=1 && rm zan.tar.gz &&     /usr/local/bin/docker-php-ext-configure /tmp/zan/zan-extension/ --enable-openssl &&     docker-php-ext-install /tmp/zan/zan-extension/ &&     rm -rf /tmp/zan/' returned a non-zero code: 2
...
```
---
ref: https://gist.github.com/RobberPhex/26f92750c855e3ec2a39033821894611